### PR TITLE
Update production_retagger.yaml

### DIFF
--- a/.github/workflows/production_retagger.yaml
+++ b/.github/workflows/production_retagger.yaml
@@ -9,7 +9,7 @@ on:
 
 env: 
   image: docker.io/uselagoon/build-deploy-image
-  tag: v0.22.0-b3d4a885
+  tag: core-v2.12.0-620efad3
 
 jobs:
   pull-tag-push:


### PR DESCRIPTION
Bump production tag build image with fixes (https://github.com/uselagoon/build-deploy-tool/compare/b3d4a885...620efad3)
https://github.com/uselagoon/build-deploy-tool/pull/183 - cronjob template fixes
https://github.com/uselagoon/build-deploy-tool/pull/187 - multiline cron fixes/validation
https://github.com/uselagoon/build-deploy-tool/pull/189 - hsts max age
https://github.com/uselagoon/build-deploy-tool/pull/184 - read replica dbaas backups
https://github.com/uselagoon/build-deploy-tool/pull/175 - mariadb skip-triggers