### PR TITLE
chore: use pr-365 from build-deploy-tool

### DIFF
--- a/.github/workflows/managed_retagger.yaml
+++ b/.github/workflows/managed_retagger.yaml
@@ -9,7 +9,7 @@ on:
 
 env: 
   image: docker.io/uselagoon/build-deploy-image
-  tag: pr-357
+  tag: pr-365
 
 jobs:
   pull-tag-push:

--- a/.github/workflows/production_retagger.yaml
+++ b/.github/workflows/production_retagger.yaml
@@ -9,7 +9,7 @@ on:
 
 env: 
   image: docker.io/uselagoon/build-deploy-image
-  tag: pr-357
+  tag: pr-365
 
 jobs:
   pull-tag-push:


### PR DESCRIPTION
This will apply pullrequests 
* 358 - sort container registries in code by name
* 355 - base image refresh support, user opt in not a change in existing behaviour
* 359 - re-label native cronjobs in kubernetes to resolve bug in ssh-portal
* 334 - reduce verbosity in build
* 349 - feature to enable cronjob to run in pod instead of native with flag
* 315 - golang versions