### PR TITLE
chore: update image to pr-423

### DIFF
--- a/.github/workflows/production_retagger.yaml
+++ b/.github/workflows/production_retagger.yaml
@@ -9,7 +9,7 @@ on:
 
 env: 
   image: docker.io/uselagoon/build-deploy-image
-  tag: core-v2.24.0
+  tag: pr-423
 
 jobs:
   pull-tag-push:


### PR DESCRIPTION
423 contains 421 and 422 aswell, which are the only things merged to main since v2.24.0 was released